### PR TITLE
Change python drop command.

### DIFF
--- a/stats-cheatsheet.rst
+++ b/stats-cheatsheet.rst
@@ -46,7 +46,7 @@ Basics
     +----------------------------------+-----------------------------------------------+----------------------------------------------+--------------------------------------------+
     |                                  | .. code-block:: none                          | .. code-block:: python                       | .. code-block:: none                       |
     |                                  |                                               |                                              |                                            |
-    | Drop variable x                  |      drop x                                   |     del x                                    |    df$x <- NULL                            |
+    | Drop variable x                  |      drop x                                   |     df = df.drop("x", axis=1)                |    df$x <- NULL                            |
     |                                  |                                               |                                              |                                            |
     |                                  |                                               |                                              |                                            |
     |                                  |                                               |                                              |                                            |


### PR DESCRIPTION
The python drop command was listed as `del x` which deletes a variable, but seems inconsistent with the rest of the commands in the cheatsheet which were oriented around mutating information inside a dataframe.

This PR changes the command `del x` to `df = df.drop("x", axis=1)` (though it could also just be `df.drop("x", axis=1, inplace=True)`).

Thoughts?

@mmcky @jstac @natashawatkins @vgregory757 