### PR TITLE
Swap workshops for blog in qe menubar

### DIFF
--- a/_themes/cheatsheet/layout.html
+++ b/_themes/cheatsheet/layout.html
@@ -59,7 +59,7 @@
             <li><a href="https://quantecon.org/julia_index.html" title="QuantEcon.jl">QuantEcon.jl</a></li>
             <li><a href="http://notebooks.quantecon.org/" title="Notebooks">Notebooks</a></li>
             <li><a href="http://cheatsheets.quantecon.org/" title="Cheatsheets">Cheatsheets</a></li>
-            <li><a href="https://quantecon.org/workshops" title="Workshops">Workshops</a></li>
+            <li><a href="http://blog.quantecon.org/" title="Blog">Blog</a></li>
             <li><a href="http://discourse.quantecon.org/" title="Forum">Forum</a></li>
             <li><a href="https://github.com/QuantEcon/" title="Repository"><span class="show-for-sr">Repository</span></a></li>
             <li><a href="https://twitter.com/quantecon" title="Twitter"><span class="show-for-sr">Twitter</span></a></li>

--- a/_themes/cheatsheet/static/css/qe-menubar.css
+++ b/_themes/cheatsheet/static/css/qe-menubar.css
@@ -62,7 +62,7 @@
 }
 .qe-menubar-nav	li	a:after {
   position: absolute;
-  content: "•";
+  content: '\2022';
   top:0;
   right:0;
   font-family: sans-serif;


### PR DESCRIPTION
Replaces the workshops link with blog link in the QE Menubar.