### PR TITLE
Hide headerlink icon at the end of linked headings #75

### DIFF
--- a/_themes/cheatsheet/static/css/custom.css
+++ b/_themes/cheatsheet/static/css/custom.css
@@ -18,6 +18,10 @@ code {
     display: none;
 }
 
+.headerlink {
+	display:none;
+}
+
 .top-bar {
 	box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 3px 1px -2px rgba(0,0,0,.2), 0 1px 5px 0 rgba(0,0,0,.12);
     background: #f8f8f8;


### PR DESCRIPTION
Hides the blue icon identifying a heading as a link — permalink icon.

<img width="751" alt="image" src="https://github.com/QuantEcon/QuantEcon.cheatsheet/assets/5886045/7708c4e7-766d-4074-a62c-69afd7f5697a">
